### PR TITLE
Change to default port

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,5 +8,5 @@ class mongodb::config {
   $logdir      = "${boxen::config::logdir}/mongodb"
   $logfile     = "${logdir}/mongodb.log"
   $consolefile = "${logdir}/console.log"
-  $port        = 17017
+  $port        = 27017
 }


### PR DESCRIPTION
Just a quick change, but I might be misunderstanding whats going on.

Is there any reason you guys pick a different port for the boxen install of mongo rather than the standard 27017?

Wouldn't it be better to change the `class mongodb::config` to the default, and if the person wants their app to use a different port, change the `mongod.conf.erb`?

Thanks! :+1: 
