### PR TITLE
Update to 2.4.1

### DIFF
--- a/files/brews/mongodb.rb
+++ b/files/brews/mongodb.rb
@@ -2,9 +2,9 @@ require 'formula'
 
 class Mongodb < Formula
   homepage 'http://www.mongodb.org/'
-  url 'http://fastdl.mongodb.org/osx/mongodb-osx-x86_64-2.2.2.tgz'
-  sha1 'b3808eeb6fe481f87db176cd3ab31119f94f7cc1'
-  version '2.2.2-boxen1'
+  url 'http://fastdl.mongodb.org/osx/mongodb-osx-x86_64-2.4.1.tgz'
+  sha1 'd11220cdaf5e8edb88b7b4cc0828ffa6149dd7b5'
+  version '2.4.1-boxen1'
 
   skip_clean :all
 


### PR DESCRIPTION
Fix for https://github.com/boxen/puppet-mongodb/issues/6 @gregimba

However, there's a pretty big bug in 2.4.1 for Ruby: https://jira.mongodb.org/browse/SERVER-8799

So, not sure if this should wait until the 2.4.2 release on the 8th April?

Your call :+1: 
