### PR TITLE
Automatically start mongod with the --rest flag.

### DIFF
--- a/templates/dev.mongodb.plist.erb
+++ b/templates/dev.mongodb.plist.erb
@@ -18,6 +18,7 @@
     <array>
       <string><%= scope.lookupvar "mongodb::config::executable" %></string>
       <string>run</string>
+      <string>--rest</string>
       <string>--config</string>
       <string><%= scope.lookupvar "mongodb::config::configfile" %></string>
     </array>


### PR DESCRIPTION
Starts `mongod` with the `--rest` flag - provides a simple REST API for data and administration.
