### PR TITLE
Upgrade of referenced version for Boxen ensure

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,7 +31,7 @@ class mongodb {
   }
 
   package { 'boxen/brews/mongodb':
-    ensure => '2.2.2-boxen1',
+    ensure => '2.4.2-boxen1',
     notify => Service['dev.mongodb']
   }
 


### PR DESCRIPTION
The referenced version in the ensure is incorrect after the upgrade to mognodb 2.4.2 
