### PR TITLE
Change resource limits in plist

### DIFF
--- a/templates/dev.mongodb.plist.erb
+++ b/templates/dev.mongodb.plist.erb
@@ -40,5 +40,16 @@
 
     <key>StandardOutPath</key>
     <string><%= scope.lookupvar "mongodb::config::consolefile" %></string>
+    
+    <key>HardResourceLimits</key>
+    <dict>
+      <key>NumberOfFiles</key>
+      <integer>1024</integer>
+    </dict>
+    <key>SoftResourceLimits</key>
+    <dict>
+      <key>NumberOfFiles</key>
+      <integer>1024</integer>
+    </dict>
   </dict>
 </plist>


### PR DESCRIPTION
This is to suppress the warnings that come from the default limit of 256 that is set on OSX. This fix was also introduced as a [pull request](https://github.com/mxcl/homebrew/pull/17523) in the Homebrew plist.
