### PR TITLE
Removed Revision from Formula

### DIFF
--- a/files/brews/mongodb.rb
+++ b/files/brews/mongodb.rb
@@ -4,7 +4,6 @@ class Mongodb < Formula
   homepage "http://www.mongodb.org/"
   url "http://downloads.mongodb.org/src/mongodb-src-r2.6.0.tar.gz"
   sha1 "35f8efe61d992f4b71c9205a9dbcab50e745c9a3"
-  revision 1
 
   version '2.6.0-boxen1'
 


### PR DESCRIPTION
This fixes #18. The revision was adding a '_1' to the version number which was confusing boxen.
