### PR TITLE
Use Clang 3.5+ compatible build flag for scons

### DIFF
--- a/files/brews/mongodb.rb
+++ b/files/brews/mongodb.rb
@@ -67,6 +67,10 @@ class Mongodb < Formula
       --osx-version-min=#{MacOS.version}
     ]
 
+    # For Yosemite with Clang 3.5+ we need this to build Mongo pre 2.7.7
+    # See: https://github.com/mongodb/mongo/pull/956#issuecomment-94545753
+    args << "--disable-warnings-as-errors" if MacOS.version == :yosemite
+
     # --full installs development headers and client library, not just binaries
     # (only supported pre-2.7)
     args << "--full" if build.stable?


### PR DESCRIPTION
On Yosemite with Clang version >= 3.5 you cannot build MongoDB
< 2.7.7 without specifying the --disable-warnings-as-errors flag.

Until this detection is done in the build file it'll have to be
passed by us in the brew formula.

Related to issue #23 